### PR TITLE
fix: catch errors on opml import and continue the process if a link i…

### DIFF
--- a/src-tauri/src/entities/feeds.rs
+++ b/src-tauri/src/entities/feeds.rs
@@ -37,10 +37,14 @@ pub fn get_folders(app_handle: tauri::AppHandle) -> Vec<String> {
         .collect()
 }
 
-pub fn create_feed(new_feed: NewFeed, app_handle: tauri::AppHandle) -> Feed {
+pub fn create_feed(mut new_feed: NewFeed, app_handle: tauri::AppHandle) -> Feed {
     use crate::schema::feeds;
 
     let conn = &mut establish_connection(&app_handle);
+
+    if new_feed.folder.is_none() {
+        new_feed.folder = Some(String::from("Quipu"));
+    }
 
     let created_feed = diesel::insert_into(feeds::table)
         .values(&new_feed)
@@ -118,6 +122,7 @@ pub fn spawn_feeds_update_loop(app_handle: tauri::AppHandle) {
 
 async fn feeds_update_loop(app_handle: tauri::AppHandle) {
     loop {
+        sleep(Duration::from_secs(1)).await;
         let conn = &mut establish_connection(&app_handle);
 
         let feeds_to_update: Vec<Feed> = feeds
@@ -143,6 +148,6 @@ async fn feeds_update_loop(app_handle: tauri::AppHandle) {
             }
         }
 
-        sleep(Duration::from_secs(61)).await;
+        sleep(Duration::from_secs(60)).await;
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -243,7 +243,7 @@ impl NewArticle {
         NewArticle {
             feed_id: feed.id,
             title: item.title,
-            link: item.link.unwrap(),
+            link: item.link.unwrap_or(feed.link.clone()),
             image: Some(String::from("")),
             pub_date: parse_rfc822_to_naive_datetime(item.pub_date),
             description: crate::core::common::remove_html_tags(item.description),

--- a/src-tauri/src/utils/opml_utils.rs
+++ b/src-tauri/src/utils/opml_utils.rs
@@ -15,10 +15,16 @@ pub async fn opml_file_to_new_feeds(
     for outline in document.body.outlines.iter() {
         if let Some(xml_url) = &outline.xml_url {
             let url = xml_url.clone();
-            let mut found_feeds = crate::utils::scrape::scrape_site_feeds(url).await?;
 
-            if let Some(first_feed) = found_feeds.pop() {
-                new_feeds.push(first_feed);
+            match crate::utils::scrape::scrape_site_feeds(url).await {
+                Ok(mut found_feeds) => {
+                    if let Some(first_feed) = found_feeds.pop() {
+                        new_feeds.push(first_feed);
+                    }
+                }
+                Err(e) => {
+                    log::error!(target: "chaski:opml","opml_file_to_new_feeds. Url: {:?} Error: {:?}", xml_url, e);
+                }
             }
         } else {
             let folder = &outline.text;
@@ -35,7 +41,7 @@ pub async fn opml_file_to_new_feeds(
                             }
                         }
                         Err(e) => {
-                            eprintln!("Error scraping feeds for URL {}: {:?}", xml_url, e);
+                            log::error!(target: "chaski:opml","opml_file_to_new_feeds. Url: {:?} Error: {:?}", xml_url, e);
                         }
                     }
                 }


### PR DESCRIPTION
OPML import was failing if a link in the file was responding wrong. Now the bad link error is catch and the process continue.

Another minor fixes were added. Default folder for feeds too (Called "Quipu").

This close #4 